### PR TITLE
[Fix/#92] 채팅 소켓 다중접속 예외처리

### DIFF
--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -220,7 +220,7 @@ export default class extends Component {
 			(!localStorage.getItem('chatConnection') ||
 				localStorage.getItem('chatConnection') !== true)
 		) {
-			this.connectSocket();
+			this.connectSocket().bind(this);
 			console.log("chat connect");
 		}
 

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -143,9 +143,13 @@ export default class extends Component {
 
 		chatSocket.onclose = function(event) {
 			console.log('WebSocket closed.');
-			displayConnectionFailedModal(
-				language.util[this.$state.region].chatMessage,
-			);
+			if(event.code === 1002){
+				console.log('Try multiple connections');
+				displayConnectionFailedModal(
+					language.util[this.$state.region].chatMessage,
+				);
+				localStorage.clear();
+			}
 			// console.log("Close event code:", event.code, "Reason:", event.reason);
 			// localStorage.clear();
 			// chatSocket.close();
@@ -172,7 +176,8 @@ export default class extends Component {
 				console.log('pong');
 				chatSocket.send(JSON.stringify({ type: 'pong' }));
 			} else if (data.type && data.type === 'send_multiple_connection') {
-				chatSocket.close();
+				chatSocket.close(1002, 'Try multiple connections');
+				chatSocket.onclose();
 			}
 		};
 	}

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -159,7 +159,7 @@ export default class extends Component {
 			);
 			localStorage.clear();
 			// localStorage.setItem('chatConnection', true);
-			chatSocket.close();
+			// chatSocket.close();
 			return;
 		};
 
@@ -171,6 +171,8 @@ export default class extends Component {
 			} else if (data.type && data.type === 'ping') {
 				console.log('pong');
 				chatSocket.send(JSON.stringify({ type: 'pong' }));
+			} else if (data.type && data.type === 'send_multiple_connection') {
+				chatSocket.close();
 			}
 		};
 	}

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -143,7 +143,7 @@ export default class extends Component {
 
 		chatSocket.onclose = function(event) {
 			console.log('WebSocket closed.');
-			if(event.code === 3000){
+			if(event.code === 1000){
 				console.log('Try multiple connections');
 				displayConnectionFailedModal(
 					language.util[this.$state.region].chatMessage,
@@ -176,7 +176,7 @@ export default class extends Component {
 				console.log('pong');
 				chatSocket.send(JSON.stringify({ type: 'pong' }));
 			} else if (data.type && data.type === 'send_multiple_connection') {
-				chatSocket.close(3000, 'Try multiple connections');
+				chatSocket.close(1000, 'Try multiple connections');
 			}
 		};
 	}

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -220,7 +220,7 @@ export default class extends Component {
 			(!localStorage.getItem('chatConnection') ||
 				localStorage.getItem('chatConnection') !== true)
 		) {
-			this.connectSocket().bind(this);
+			this.connectSocket().bind(this)();
 			console.log("chat connect");
 		}
 

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -143,7 +143,7 @@ export default class extends Component {
 
 		chatSocket.onclose = function(event) {
 			console.log('WebSocket closed.');
-			if(event.code === 1002){
+			if(event.code === 3000){
 				console.log('Try multiple connections');
 				displayConnectionFailedModal(
 					language.util[this.$state.region].chatMessage,
@@ -176,8 +176,7 @@ export default class extends Component {
 				console.log('pong');
 				chatSocket.send(JSON.stringify({ type: 'pong' }));
 			} else if (data.type && data.type === 'send_multiple_connection') {
-				chatSocket.close(1002, 'Try multiple connections');
-				chatSocket.onclose();
+				chatSocket.close(3000, 'Try multiple connections');
 			}
 		};
 	}

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -220,7 +220,7 @@ export default class extends Component {
 			(!localStorage.getItem('chatConnection') ||
 				localStorage.getItem('chatConnection') !== true)
 		) {
-			this.connectSocket().bind(this)();
+			this.connectSocket.bind(this)();
 			console.log("chat connect");
 		}
 

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -146,7 +146,7 @@ export default class extends Component {
 			if(event.code === 1000){
 				console.log('Try multiple connections');
 				displayConnectionFailedModal(
-					language.util[this.$state.region].chatMessage,
+					language.util[localStorage.getItem('language')?localStorage.getItem('language'):'en'].chatMessage,
 				);
 				localStorage.clear();
 			}

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -23,8 +23,9 @@ export default class extends Component {
 			if (localStorage.getItem('tournament-id')) {
 				localStorage.removeItem('tournament-id');
 			}
-			navigate("/select", true);
-			// window.location.pathname = '/select';
+			if (window.location.pathname !== 'remote' && window.location.pathname !== 'game'){
+				navigate("/select", true);
+			}
 		});
 
 		this.addEvent('click', '.modal-close-btn', () => {

--- a/src/pages/components/game_select/GameSelect.js
+++ b/src/pages/components/game_select/GameSelect.js
@@ -10,8 +10,7 @@ export default class extends Component {
 	async setup() {
 		if (
 			!localStorage.getItem('accessToken') ||
-			!localStorage.getItem('twoFA')
-		) {
+			!localStorage.getItem('twoFA')) {
 			window.location.pathname = '/login';
 			// navigate("/login", true);
 		} else {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -9,7 +9,10 @@ function Router($container) {
 		routes.find((route) => route.path.test(location.pathname));
 
 	const route = () => {
-		currentPage = null;
+		if (currentPage){
+			currentPage.destroy();
+			currentPage = null;
+		}
 		const TargetPage = findMatchedRoute()?.element || NotFound;
 		currentPage = new TargetPage(this.$container);
 	};


### PR DESCRIPTION
### 이슈
채팅 소켓 다중접속 처리를 프론트에서 못 받는 문제
### 해결 방법
서버에서 다중 접속을 연결 후 즉시 이벤트를 보내주는 방식으로 수정
### 세부 수정사항
- chat socket onclose 코드 분기
- chat socket onmessage 이벤트 추가(send_multiple_connection)
- chat socket onerror 수정