### PR TITLE
[Fix/#134] 메인 로고 클릭 시 이동 새로고침

### DIFF
--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -42,7 +42,8 @@ export default class App extends Component {
 				window.location.pathname !== '/remote' &&
 				window.location.pathname !== '/game'
 			) {
-				navigate('/select', true);
+				// navigate('/select');
+				window.location.pathname = '/select';
 			}
 		});
 

--- a/src/pages/components/App.js
+++ b/src/pages/components/App.js
@@ -42,7 +42,7 @@ export default class App extends Component {
 				window.location.pathname !== '/remote' &&
 				window.location.pathname !== '/game'
 			) {
-				navigate('/select');
+				navigate('/select', true);
 			}
 		});
 

--- a/src/pages/components/remote/Remote.js
+++ b/src/pages/components/remote/Remote.js
@@ -62,7 +62,8 @@ export default class Remote extends Component {
 				await this.stopCounter();
 				document.removeEventListener('click', cancelEvent);
 				window.removeEventListener('popstate', popEvent);
-				navigate('/select');
+				// navigate('/select');
+				window.location.pathname = '/select';
 			}
 		};
 		document.addEventListener('click', cancelEvent);
@@ -190,7 +191,8 @@ export default class Remote extends Component {
 					language.remote[this.$state.region].cancelMatch,
 					document.querySelector('.mainbox'),
 				);
-				navigate('/select');
+				// navigate('/select');
+				window.location.pathname = '/select';
 			}
 		};
 


### PR DESCRIPTION
navigate로 이동했을 때 게임선택 창의 게임 설명 인풋 버튼이 안 눌리는 버그가 있어서 navigate 제거하고 pathname 고치는 방식으로 수정했습니다. (remote, app)